### PR TITLE
fix(docker): update Go version to 1.25.1 and fix container builds

### DIFF
--- a/build/me-site/Dockerfile
+++ b/build/me-site/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/library/golang:1.22.3-alpine3.18 AS build
+FROM docker.io/library/golang:1.25.1-alpine3.22 AS build
 
 RUN echo 'nobody:x:65534:65534:Nobody:/:' > /tmp/passwd && \
-    apk add --no-cache upx=4.0.2-r0
+    apk add --no-cache upx=5.0.2-r0
 
 WORKDIR /go/src/github.com/lexfrei/tools/
 COPY . /go/src/github.com/lexfrei/tools/

--- a/build/ow-exporter/Dockerfile
+++ b/build/ow-exporter/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/library/golang:1.22.3-alpine3.18 AS build
+FROM docker.io/library/golang:1.25.1-alpine3.22 AS build
 
 RUN echo 'nobody:x:65534:65534:Nobody:/:' > /tmp/passwd && \
-    apk add --no-cache upx=4.0.2-r0
+    apk add --no-cache upx=5.0.2-r0
 
 WORKDIR /go/src/github.com/lexfrei/tools/
 COPY . /go/src/github.com/lexfrei/tools/

--- a/build/vk2tg/Dockerfile
+++ b/build/vk2tg/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/golang:1.22.3-alpine3.18 AS build
+FROM docker.io/library/golang:1.25.1-alpine3.22 AS build
 
 RUN echo 'nobody:x:65534:65534:Nobody:/:' > /tmp/passwd && \
-    apk add --no-cache upx=4.0.2-r0
+    apk add --no-cache upx=5.0.2-r0
 
-WORKDIR /go/src/github.com/lexfrei/vk2tg/
-COPY . /go/src/github.com/lexfrei/vk2tg/
+WORKDIR /go/src/github.com/lexfrei/tools/
+COPY . /go/src/github.com/lexfrei/tools/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" ./cmd/vk2tg/vk2tg.go && \
     upx --best --lzma vk2tg
@@ -13,7 +13,7 @@ FROM scratch
 
 COPY --from=build /tmp/passwd /etc/passwd
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /go/src/github.com/lexfrei/vk2tg/vk2tg /
+COPY --from=build /go/src/github.com/lexfrei/tools/vk2tg /
 
 USER nobody
 ENTRYPOINT ["/vk2tg"]


### PR DESCRIPTION
## Summary
- Update Go version from 1.22.3 to 1.25.1-alpine3.22 in all Dockerfiles
- Update upx from 4.0.2-r0 to 5.0.2-r0 for Alpine 3.22 compatibility  
- Fix vk2tg Dockerfile paths (WORKDIR and COPY directives were incorrect)

## Problem
CI container builds were failing because:
- `go.mod` requires Go >= 1.25
- Dockerfiles used outdated Go 1.22.3
- upx version was incompatible with newer Alpine
- vk2tg had incorrect paths in Dockerfile

## Test plan
- [x] Local Docker builds tested successfully for me-site and vk2tg
- [ ] CI builds should now pass on GitHub Actions
- [ ] All container images should build and deploy correctly

Fixes container build failures in CI workflows.