### PR TITLE
fix(ci): unblock Renovate by fixing lint and migrating to shared preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,67 +1,13 @@
 {
-    "major": {
-        "stabilityDays": 3
-    },
-    "schedule": [
-        "before 2am"
-    ],
-    "timezone": "Europe/Moscow",
-    "dependencyDashboard": true,
-    "packageRules": [
-        {
-            "managers": [
-                "gomod"
-            ],
-            "updateTypes": [
-                "major"
-            ],
-            "postUpdateOptions": [
-                "gomodTidy",
-                "gomodUpdateImportPaths"
-            ],
-            "labels": [
-                "go major update"
-            ]
-        },
-        {
-            "managers": [
-                "gomod"
-            ],
-            "updateTypes": [
-                "minor",
-                "patch",
-                "pin",
-                "digest"
-            ],
-            "postUpdateOptions": [
-                "gomodTidy",
-                "gomodUpdateImportPaths"
-            ],
-            "labels": [
-                "go minor update"
-            ]
-        },
-        {
-            "matchDatasources": [
-                "docker"
-            ],
-            "labels": [
-                "docker update"
-            ],
-            "automerge": true
-        },
-        {
-            "matchDatasources": [
-                "github-actions",
-                "actions"
-            ],
-            "labels": [
-                "actions update"
-            ]
-        }
-    ],
-    "ignorePaths": [
-        "vendor/**"
-    ],
-    "automerge": true
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>lexfrei/renovate-config"],
+  "schedule": ["before 2am"],
+  "timezone": "Europe/Moscow",
+  "packageRules": [
+    {
+      "description": "Hold major updates back for a few days to let the ecosystem settle",
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
 }

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -23,4 +23,6 @@ jobs:
       - name: Run golangci
         uses: golangci/golangci-lint-action@v9.2.1
         with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           args: --timeout 5m

--- a/cmd/mtgdsgenerator/mtgdsgenerator.go
+++ b/cmd/mtgdsgenerator/mtgdsgenerator.go
@@ -90,7 +90,6 @@ func main() {
 
 	log.Printf("Spawning %d workers...\n", cmd.Parallel)
 
-	//nolint:gosec // not interesting
 	workersCount := int(cmd.Parallel)
 	jobIndex := make(chan int, workersCount)
 


### PR DESCRIPTION
## Why

The required "Lint Go" check is red on master because golangci-lint-action resolved to the latest release (v2.12.2), under which nolintlint flags one unused suppression on pre-existing code. The red check blocks Renovate's open PRs from merging.

## What

- Remove the now-unused `//nolint:gosec` directive in `cmd/mtgdsgenerator`. gosec no longer flags the uint-to-int conversion of the parallel-workers flag, so the directive only triggered nolintlint.
- Pin golangci-lint in the Lint Go workflow to a fixed, Renovate-tracked version instead of relying on implicit "latest". This makes CI reproducible and routes future linter bumps through a reviewable PR.
- Migrate `.github/renovate.json` to extend the shared `lexfrei/renovate-config` preset. Redundant automerge, label and gomodTidy keys are dropped because the preset already provides them. The nightly schedule with the Europe/Moscow timezone is kept as a genuine override, and the major-update hold is retained using the current `minimumReleaseAge` option in place of the deprecated `stabilityDays`.

## Verification

- `go build ./...` succeeds.
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` reports 0 issues (local v2.12.2, matching CI).
- `go test ./...` passes.
- `gofmt` reports no changes.
- The Renovate config validates with `renovate-config-validator`.